### PR TITLE
Use string macro to fix build for MakeCode beta

### DIFF
--- a/SSD1306_OLED.cpp
+++ b/SSD1306_OLED.cpp
@@ -12,7 +12,6 @@ namespace OLED {
 	#define PXT_STRING_DATA(str) str->data
 	#endif
 
-
 	MicroBitI2C i2c(I2C_SDA0, I2C_SCL0);
 	Adafruit_SSD1306_I2c *oled;
 

--- a/SSD1306_OLED.cpp
+++ b/SSD1306_OLED.cpp
@@ -7,6 +7,11 @@ namespace OLED {
 	#define SSD1306_ADDRESS 0x78
 	#undef printf
 
+	// maintain compatibility with pre-unicode versions of microbit
+	#ifndef PXT_STRING_DATA
+	#define PXT_STRING_DATA(str) str->data
+	#endif
+
 
 	MicroBitI2C i2c(I2C_SDA0, I2C_SCL0);
 	Adafruit_SSD1306_I2c *oled;
@@ -30,13 +35,13 @@ namespace OLED {
 
 	//%
     void showStringNoNewLine(String text) {
-		oled->printf("%s", PXT_BUFFER_DATA(text));
+		oled->printf("%s", PXT_STRING_DATA(text));
 		oled->display();
     }
 
 	//%
     void showStringWithNewLine(String text) {
-		oled->printf("%s\n", PXT_BUFFER_DATA(text));
+		oled->printf("%s\n", PXT_STRING_DATA(text));
 		oled->display();
     }
 	


### PR DESCRIPTION
See https://github.com/Microsoft/pxt-common-packages/pull/782; both buffers and strings had data fields, so using the buffer macro was working until unicode support broke the parity between the two objects.

The build for beta won't fix until the next version bump in micro:bit, as it hasn't quite picked up the common packages changes yet, but this should maintain compatibility from that point onwards / work the same as it currently does until then. 

@pelikhan could you sanity check this real quick?