### PR TITLE
add zhcn translations

### DIFF
--- a/_locales/zh/oled-strings.json
+++ b/_locales/zh/oled-strings.json
@@ -1,0 +1,12 @@
+{
+	"OLED.init|block": "OLED 初始化 宽 %width 高 %height",
+    "OLED.drawRectangle|block": "绘制矩形 起点:|x: $x0 y: $y0 终点| x: $x1 y: $y1",
+    "OLED.writeStringNewLine|block": "新行显示字符串 $str",
+    "OLED.writeNumNewLine|block": "新行显示数字 $n",
+    "OLED.writeString|block": "显示字符串 $str",
+    "OLED.writeNum|block": "显示数字 $n",
+    "OLED.clear|block": "清除显示",
+    "OLED.newLine|block": "新行",
+    "OLED.drawLoading|block": "显示进度条 $percent %",
+    "OLED.drawLine|block": "画线条 起点:|x: $x0 y: $y0 终点| x: $x1 y: $y1"
+}

--- a/pxt.json
+++ b/pxt.json
@@ -8,7 +8,8 @@
     },
     "files": [
         "README.md",
-        "main.ts"
+        "main.ts",
+        "_locales/zh/oled-strings.json"
     ],
     "testFiles": [
         "test.ts"


### PR DESCRIPTION
This extension is widely used in China mainland, many educators wish there will be a localized translation.